### PR TITLE
BugFix for lack of end call on readline interface

### DIFF
--- a/arff.js
+++ b/arff.js
@@ -36,6 +36,7 @@ module.exports = function arff(input) {
       emitter.emit('error', new Error('Unknown input:'+input));
     });
   }
+  var writeStream = fs.createWriteStream('/dev/null');
   var handlers = {
     line: function(line) {
       if (!section) section = 'header';
@@ -77,6 +78,7 @@ module.exports = function arff(input) {
     },
     end: function() {
       emitter.emit('end');
+      writeStream.end();
     },
     error: function(err) {
       emitter.emit('error', err);
@@ -85,7 +87,7 @@ module.exports = function arff(input) {
 
   lines = readline.createInterface({
     input: is,
-    output: fs.createWriteStream('/dev/null')
+    output: writeStream
   });
   lines.on('line', handlers.line);
   lines.on('error', handlers.error);


### PR DESCRIPTION
@chesles Excellent library *but* you left the write streams open on the null device. After calling this library sequentially on 200+ files you will eventually notice that the file handles are being held on the output stream for the readline interface.

Please verify, integrate and publish up a new NPM package for those of us using your helpful library.

Thanks for building this! 